### PR TITLE
ARM64: Ensure module fixup node data is aligned

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -41,6 +41,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+
             builder.AddSymbol(this);
 
             ISymbolNode nameSymbol = factory.ConstantUtf8String(_pInvokeModuleData.ModuleName);


### PR DESCRIPTION
Data is updated with a compare exchange operation. Therefore it needs to be aligned or it will trigger a data exception on ARM64 CPUs