### PR TITLE
ARM64: Fix Android linker issues

### DIFF
--- a/src/Native/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm64.inc
@@ -21,16 +21,19 @@ C_FUNC(\Name):
 
 .macro ALTERNATE_ENTRY Name
         .global C_FUNC(\Name)
+        .hidden C_FUNC(\Name)
 C_FUNC(\Name):
 .endm
 
 .macro LABELED_RETURN_ADDRESS Name
         .global C_FUNC(\Name)
+        .hidden C_FUNC(\Name)
 C_FUNC(\Name):
 .endm
 
 .macro LEAF_ENTRY Name, Section
         .global C_FUNC(\Name)
+        .hidden C_FUNC(\Name)
         .type \Name, %function
 C_FUNC(\Name):
         .cfi_startproc
@@ -207,8 +210,9 @@ C_FUNC(\Name):
         .data
         .align      8
 C_FUNC(\Name):
-        .word       1b
+        .quad       1b
         .global     C_FUNC(\Name)
+        .hidden     C_FUNC(\Name)
         .text
 .endm
 

--- a/src/Native/libunwind/src/Registers.hpp
+++ b/src/Native/libunwind/src/Registers.hpp
@@ -2174,6 +2174,8 @@ inline const char *Registers_arm64::getRegisterName(int regNum) {
   }
 }
 
+inline void Registers_arm64::jumpto() {}
+
 inline bool Registers_arm64::validFloatRegister(int regNum) const {
   if (regNum < UNW_ARM64_D0)
     return false;


### PR DESCRIPTION
- Add implementation for unused function in libunwind that is not removed by the Android linker
- Fix the data type for the pointer to return address macro as the android linker did not relocate the full address with the wrong type
- Make all assembler functions hidden. This way they are not added to the GOT. This forces the linker to resolve all calls to the functions itself instead of using the PLT. Using the PLT will trash X16&X17. Some of the functions implemented in assembler require that these two register are not changed. Beside of this using the PLT adds more overhead.